### PR TITLE
Fix markdown heading regex

### DIFF
--- a/lib/markdownUtils.ts
+++ b/lib/markdownUtils.ts
@@ -24,7 +24,7 @@ export function styleMarkdownContent(content: string): string {
             '<h2 class="markdown-h2">$1</h2>'
         )
         .replace(
-            /### (.+)/g,
+            /^### (.+)$/gm,
             '<h3 class="markdown-h3">$1</h3>'
         )
         .replace(


### PR DESCRIPTION
## Summary
- ensure h3 markdown headings only match start of line to prevent accidental replacements

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6894eb5c7f088329b48cab2d1cd37bc5